### PR TITLE
Fix undefined indexes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ function p2pSocket (socket, next, room) {
     delete clients[socket.id]
     Object.keys(connectedClients).forEach(function (clientId, i) {
       var client = clients[clientId]
-      client.emit('peer-disconnect', {peerId: socket.id})
+      if (client) {
+        client.emit('peer-disconnect', {peerId: socket.id})
+      }
     })
     debug('Client gone (id=' + socket.id + ').')
   })
@@ -28,9 +30,11 @@ function p2pSocket (socket, next, room) {
       var client = clients[clientId]
       if (client !== socket) {
         var offerObj = data.offers[i]
-        var emittedOffer = {fromPeerId: socket.id, offerId: offerObj.offerId, offer: offerObj.offer}
-        debug('Emitting offer: %s', JSON.stringify(emittedOffer))
-        client.emit('offer', emittedOffer)
+        if (offerObj) {
+          var emittedOffer = {fromPeerId: socket.id, offerId: offerObj.offerId, offer: offerObj.offer}
+          debug('Emitting offer: %s', JSON.stringify(emittedOffer))
+          client.emit('offer', emittedOffer)
+        }
       }
     })
   })
@@ -39,7 +43,9 @@ function p2pSocket (socket, next, room) {
     var toPeerId = data.toPeerId
     debug('Signal peer id %s', toPeerId);
     var client = clients[toPeerId]
-    client.emit('peer-signal', data)
+    if (client) {
+      client.emit('peer-signal', data)
+    }
   })
   typeof next === 'function' && next()
 }


### PR DESCRIPTION
When a p2p client quits or reconnect a p2p server really quickly, the client may be undefined for the clients array. Same goes with the data.offers array.